### PR TITLE
Create deps directory

### DIFF
--- a/bundle/package.json
+++ b/bundle/package.json
@@ -1,5 +1,6 @@
 {
     "scripts": {
+        "prebundle": "node -r fs -e fs.mkdirSync('../extension/pages/graph/deps')",
         "bundle": "rollup -c | uglifyjs -c -m -o ../extension/pages/graph/deps/d3.min.js",
         "clean": "rm -f ../extension/pages/graph/deps/d3.min.js"
     },


### PR DESCRIPTION
"npm run bundle" failed for me (running on Windows 7) because the output directory for uglifyjs did not exist. I made it create the directory first.

Here's the error it was getting before my change:
```
fs.js:557
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open 'C:\Source\test\chrome-page-graph\extension\pages\graph\deps\d3.min.js'
    at Object.fs.openSync (fs.js:557:18)
    at Object.fs.writeFileSync (fs.js:1214:33)
    at C:\Source\test\chrome-page-graph\bundle\node_modules\uglify-js\bin\uglifyjs:496:16
    at C:\Source\test\chrome-page-graph\bundle\node_modules\async\lib\async.js:188:33
    at C:\Source\test\chrome-page-graph\bundle\node_modules\uglify-js\bin\uglifyjs:384:9
    at Socket.<anonymous> (C:\Source\test\chrome-page-graph\bundle\node_modules\uglify-js\bin\uglifyjs:570:13)
    at emitNone (events.js:91:20)
    at Socket.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:974:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
```